### PR TITLE
Limit memory usage and time execution

### DIFF
--- a/lib/live_view_demo/sandbox.ex
+++ b/lib/live_view_demo/sandbox.ex
@@ -1,0 +1,60 @@
+defmodule LiveViewDemo.Sandbox do
+  require Logger
+
+  # 30 kb
+  @max_memory_usage 1024 * 30
+
+  def execute(command, bindings) do
+    task = Task.async(fn -> execute_code(command, bindings) end)
+
+    case check_memory_and_result(task) do
+      {:ok, {:success, result}} ->
+        {:success, result}
+
+      {:ok, {:error, result}} ->
+        {:error, result}
+
+      :timeout ->
+        {:error, "The command was cancelled due to timeout"}
+
+      :memory_abuse ->
+        {:error, "The command used more memory than allowed"}
+    end
+  end
+
+  defp check_memory_and_result(task, attempts \\ 100)
+
+  defp check_memory_and_result(task, 0) do
+    Task.shutdown(task)
+    :timeout
+  end
+
+  defp check_memory_and_result(task, attempts) do
+    case Task.yield(task, 50) do
+      {:ok, result} ->
+        {:ok, result}
+
+      nil ->
+        if allowed_memory_usage?(task) do
+          check_memory_and_result(task, attempts - 1)
+        else
+          Task.shutdown(task)
+          :memory_abuse
+        end
+    end
+  end
+
+  defp allowed_memory_usage?(task) do
+    {:memory, memory} = Process.info(task.pid, :memory)
+    memory <= @max_memory_usage
+  end
+
+  defp execute_code(command, bindings) do
+    {result, bindings} = Code.eval_string(command, bindings)
+    {:success, {result, bindings}}
+  catch
+    kind, error ->
+      error = Exception.normalize(kind, error)
+      {:error, inspect(error)}
+  end
+end

--- a/lib/live_view_demo/sandbox.ex
+++ b/lib/live_view_demo/sandbox.ex
@@ -1,13 +1,13 @@
 defmodule LiveViewDemo.Sandbox do
   require Logger
 
-  # 30 kb
+  # Limit to 30 kb the memory usage per command
   @max_memory_usage 1024 * 30
 
   def execute(command, bindings) do
     task = Task.async(fn -> execute_code(command, bindings) end)
 
-    case check_memory_and_result(task) do
+    case check_task_status(task) do
       {:ok, {:success, result}} ->
         {:success, result}
 
@@ -22,21 +22,21 @@ defmodule LiveViewDemo.Sandbox do
     end
   end
 
-  defp check_memory_and_result(task, attempts \\ 100)
+  defp check_task_status(task, ticks \\ 100)
 
-  defp check_memory_and_result(task, 0) do
+  defp check_task_status(task, 0) do
     Task.shutdown(task)
     :timeout
   end
 
-  defp check_memory_and_result(task, attempts) do
+  defp check_task_status(task, ticks) do
     case Task.yield(task, 50) do
       {:ok, result} ->
         {:ok, result}
 
       nil ->
         if allowed_memory_usage?(task) do
-          check_memory_and_result(task, attempts - 1)
+          check_task_status(task, ticks - 1)
         else
           Task.shutdown(task)
           :memory_abuse

--- a/lib/live_view_demo_web/live/console_live.ex
+++ b/lib/live_view_demo_web/live/console_live.ex
@@ -2,7 +2,7 @@ defmodule LiveViewDemoWeb.ConsoleLive do
   use Phoenix.LiveView
   import Phoenix.HTML, only: [sigil_e: 2]
 
-  alias LiveViewDemo.Documentation
+  alias LiveViewDemo.{ContextualHelp, Documentation, Sandbox}
 
   defmodule Output do
     @enforce_keys [:command, :id]
@@ -181,7 +181,11 @@ defmodule LiveViewDemoWeb.ConsoleLive do
     end
   end
 
-  def handle_event("show_contextual_info", %{"func_name" => func_name, "header" => header, "doc" => doc, "link" => link}, socket) do
+  def handle_event(
+        "show_contextual_info",
+        %{"func_name" => func_name, "header" => header, "doc" => doc, "link" => link},
+        socket
+      ) do
     {:noreply,
      socket
      |> assign(contextual_help: %{func_name: func_name, header: header, doc: doc, link: link})
@@ -189,9 +193,10 @@ defmodule LiveViewDemoWeb.ConsoleLive do
   end
 
   defp execute_command(command, bindings) do
-    case LiveViewDemo.Sandbox.execute(command, bindings) do
+    case Sandbox.execute(command, bindings) do
       {:success, {result, bindings}} ->
         {:ok, inspect(result), bindings}
+
       {:error, error_string} ->
         {:error, error_string}
     end
@@ -203,8 +208,11 @@ defmodule LiveViewDemoWeb.ConsoleLive do
     |> assign(command_id: socket.assigns.command_id + 1)
   end
 
-  defp build_output(:ok, command, result, id), do: %Output{command: command, result: result, id: id}
-  defp build_output(:error, command, error, id), do: %Output{command: command, error: error, id: id}
+  defp build_output(:ok, command, result, id),
+    do: %Output{command: command, result: result, id: id}
+
+  defp build_output(:error, command, error, id),
+    do: %Output{command: command, error: error, id: id}
 
   defp print_prompt, do: "> "
 
@@ -221,10 +229,15 @@ defmodule LiveViewDemoWeb.ConsoleLive do
   end
 
   defp splitted_command(command) do
-    LiveViewDemo.ContextualHelp.compute(command)
+    ContextualHelp.compute(command)
   end
 
-  defp render_command_inline_help(part, %{func_name: func_name, header: header, docs: docs, link: link}) do
+  defp render_command_inline_help(part, %{
+         func_name: func_name,
+         header: header,
+         docs: docs,
+         link: link
+       }) do
     ~e{<span
       phx-click="show_contextual_info"
       phx-value-func_name="<%= func_name %>"

--- a/lib/live_view_demo_web/live/console_live.ex
+++ b/lib/live_view_demo_web/live/console_live.ex
@@ -189,12 +189,12 @@ defmodule LiveViewDemoWeb.ConsoleLive do
   end
 
   defp execute_command(command, bindings) do
-    {result, bindings} = Code.eval_string(command, bindings)
-    {:ok, inspect(result), bindings}
-  catch
-    kind, error ->
-      error = Exception.normalize(kind, error)
-      {:error, inspect(error)}
+    case LiveViewDemo.Sandbox.execute(command, bindings) do
+      {:success, {result, bindings}} ->
+        {:ok, inspect(result), bindings}
+      {:error, error_string} ->
+        {:error, error_string}
+    end
   end
 
   defp append_output(socket, status, command, result_or_error) do


### PR DESCRIPTION
This PR aims to limit the resources consumed by user-generated commands in the console.

The strategy is to run the code in a task and then check the memory consumption periodically (every 50ms) until task finalization or timeout is reached. If memory usage in the process used to execute the command exceed a defined limit, the task is interrupted and the user is informed about this fact.

This solution should be complemented with other measures in order to execute code in a "sandboxed mode". In particular, we are likely to disallow code creating processes (eg `spawn`, `Task.async`, etc) because it's harder to control individual processes that could abuse memory usage or keep waiting for a message. 